### PR TITLE
etcdbk tar tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ Etcdbk is a tool for backing up the values in a live etcd cluster.
 
 Etcdbk generates a tarball (tar.gz) with paths matching the keys in your etcd cluster. Etcdbk uses the etcd API instead of direct access to the etcd data directory, thus allowing backups to be generated on machines remote to the target cluster, or from within application containers.
 
-**Caveat:** Because etcdbk only adds keys to resulting artifact, etcd paths that have no keys will be lost.
-
 ## Installation
 
 ```shell

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/coreos/go-etcd/etcd"
 	"github.com/jessevdk/go-flags"
+	"os"
 )
 
 var opts struct {
@@ -14,6 +15,7 @@ var opts struct {
 var parser = flags.NewParser(&opts, flags.Default)
 
 func init() {
+	log.SetOutput(os.Stderr)
 	opts.Verbose = func() {
 		log.SetLevel(log.DebugLevel)
 	}

--- a/tarball.go
+++ b/tarball.go
@@ -14,12 +14,13 @@ func FillTarballBuffer(rootNode *etcd.Node) *bytes.Buffer {
 	buffer := bytes.NewBuffer(nil)
 
 	gzipWriter := gzip.NewWriter(buffer)
-	w := tar.NewWriter(gzipWriter)
+	tarWriter := tar.NewWriter(gzipWriter)
 
-	defer w.Close()
+	// LIFO order; close the tar writer, then the gzip writer.
 	defer gzipWriter.Close()
+	defer tarWriter.Close()
 
-	writeNode(w, rootNode)
+	writeNode(tarWriter, rootNode)
 
 	return buffer
 }
@@ -27,6 +28,16 @@ func FillTarballBuffer(rootNode *etcd.Node) *bytes.Buffer {
 func writeNode(w *tar.Writer, node *etcd.Node) { // I'm recursive!
 	log.WithField("key", node.Key).Debug("writing to tarball")
 	if node.Dir {
+		// Always write a header for a directory, unless it's the root.
+		if len(node.Key) > 0 {
+			w.WriteHeader(&tar.Header{
+				// Always strip the leading slash from the key.
+				Name:   node.Key[1:] + "/",
+				Mode:   0755,
+				Xattrs: nodeXattrs(node),
+			})
+		}
+
 		for _, subNode := range node.Nodes {
 			writeNode(w, subNode) // see?
 		}
@@ -34,23 +45,28 @@ func writeNode(w *tar.Writer, node *etcd.Node) { // I'm recursive!
 	}
 
 	buf := bytes.NewBuffer([]byte(node.Value))
-	expiration := func() string {
-		if node.Expiration == nil {
-			return "never"
-		} else {
-			return node.Expiration.Format(time.RFC3339)
-		}
-	}()
-
 	w.WriteHeader(&tar.Header{
-		Name: node.Key,
-		Mode: 0444,
-		Size: int64(buf.Len()),
-		Xattrs: map[string]string{
-			"ModifiedIndex": fmt.Sprintf("%d", node.ModifiedIndex),
-			"CreatedIndex":  fmt.Sprintf("%d", node.CreatedIndex),
-			"Expiration":    expiration,
-		},
+		// Always strip the leading slash from the key.
+		Name:   node.Key[1:],
+		Mode:   0644,
+		Size:   int64(buf.Len()),
+		Xattrs: nodeXattrs(node),
 	})
 	buf.WriteTo(w)
+}
+
+func nodeExpiration(node *etcd.Node) string {
+	if node.Expiration == nil {
+		return "never"
+	} else {
+		return node.Expiration.Format(time.RFC3339)
+	}
+}
+
+func nodeXattrs(node *etcd.Node) map[string]string {
+	return map[string]string{
+		"ModifiedIndex": fmt.Sprintf("%d", node.ModifiedIndex),
+		"CreatedIndex":  fmt.Sprintf("%d", node.CreatedIndex),
+		"Expiration":    nodeExpiration(node),
+	}
 }


### PR DESCRIPTION
- Fix issue with tar file not being fully written out.
- Write tar entries for empty dirs, erasing one of the listed caveats
- Write dirs with good permissions so that the files can be read out
  after extracting with a normal tar app.
- Write log output to stderr, so that it doesn't interfere with using
  etcdbk in a shell pipeline.
- Factor out nodeExpiration and nodeXattrs into helper functions.
